### PR TITLE
Add input validation for solar panel energy calculation

### DIFF
--- a/native_ai_quantum_energy/energy_simulator.py
+++ b/native_ai_quantum_energy/energy_simulator.py
@@ -18,9 +18,11 @@ def solar_panel_output(power_watt: float, hours: float, efficiency: float = 0.15
     Parameters
     ----------
     power_watt : float
-        The nominal power rating of the panel in watts (W).
+        The nominal power rating of the panel in watts (W).  Must be
+        non‑negative.
     hours : float
-        Number of hours the panel operates under rated conditions.
+        Number of hours the panel operates under rated conditions.  Must be
+        non‑negative.
     efficiency : float, optional
         Conversion efficiency (0 ≤ efficiency ≤ 1).  Defaults to 0.15 (15 %).
 
@@ -36,6 +38,8 @@ def solar_panel_output(power_watt: float, hours: float, efficiency: float = 0.15
     factors.  This simplified function treats the rated power and efficiency
     as constants over the specified duration.
     """
+    if power_watt < 0 or hours < 0:
+        raise ValueError("Power and hours must be non-negative")
     if efficiency < 0 or efficiency > 1:
         raise ValueError("Efficiency must be between 0 and 1")
     # Convert hours to seconds to compute energy in joules

--- a/tests/test_energy_simulator.py
+++ b/tests/test_energy_simulator.py
@@ -1,0 +1,22 @@
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+from native_ai_quantum_energy.energy_simulator import solar_panel_output
+
+
+def test_solar_panel_output_valid():
+    energy = solar_panel_output(100, 2, 0.5)
+    assert energy == pytest.approx(100 * 0.5 * 2 * 3600)
+
+
+def test_solar_panel_output_negative_power():
+    with pytest.raises(ValueError):
+        solar_panel_output(-10, 1)
+
+
+def test_solar_panel_output_negative_hours():
+    with pytest.raises(ValueError):
+        solar_panel_output(10, -1)


### PR DESCRIPTION
## Summary
- validate that solar panel power and operating hours are non-negative
- cover solar panel output calculations with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b380b874d88329a46f763eb5b65c33