### PR TITLE
Add CI workflow to run pytest for simulators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.py[cod]
+*.py.cache
+.pytest_cache/
+.env
+.venv
+venv/
+ENV/
+Pipfile.lock
+poetry.lock
+.DS_Store


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs Python 3.12 and runs pytest on pushes and pull requests
- add a project-level .gitignore to avoid committing caches and virtual environments

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912c7ee3a908329bc391e9c5f2dda40)